### PR TITLE
feat: franchiser expiration feature and initial tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,18 +9,18 @@ optimizer_runs = 1000000
 bytecode_hash = "none"
 
 [profile.ci]
-  fuzz = { runs = 5000 }
-  invariant = { runs = 1000 }
+fuzz = { runs = 500 }
+invariant = { runs = 50 }
 
 [invariant]
-  call_override = false
-  depth = 100
-  dictionary_weight = 80
-  fail_on_revert = false
-  include_push_bytes = true
-  include_storage = true
-  optimizer = false
-  runs = 25
+call_override = false
+runs = 25
+depth = 100
+dictionary_weight = 80
+fail_on_revert = false
+include_push_bytes = true
+include_storage = true
+optimizer = false
 
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/FranchiserFactory.sol
+++ b/src/FranchiserFactory.sol
@@ -20,6 +20,9 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
     /// @inheritdoc IFranchiserFactory
     Franchiser public immutable franchiserImplementation;
 
+    /// @inheritdoc IFranchiserFactory
+    mapping(Franchiser => uint256) public expirations;
+
     constructor(IVotingToken votingToken_)
         FranchiserImmutableState(votingToken_)
     {
@@ -50,7 +53,7 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
     }
 
     /// @inheritdoc IFranchiserFactory
-    function fund(address delegatee, uint256 amount)
+    function fund(address delegatee, uint256 amount, uint256 expiration)
         public
         returns (Franchiser franchiser)
     {
@@ -66,6 +69,9 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
                 INITIAL_MAXIMUM_SUBDELEGATEES
             );
         }
+        if (expiration < block.timestamp) revert InvalidExpiration();
+        expirations[franchiser] = expiration;
+
         ERC20(address(votingToken)).safeTransferFrom(
             msg.sender,
             address(franchiser),
@@ -74,7 +80,7 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
     }
 
     /// @inheritdoc IFranchiserFactory
-    function fundMany(address[] calldata delegatees, uint256[] calldata amounts)
+    function fundMany(address[] calldata delegatees, uint256[] calldata amounts, uint256 expiration)
         external
         returns (Franchiser[] memory franchisers)
     {
@@ -84,7 +90,7 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
         franchisers = new Franchiser[](delegatees.length);
         unchecked {
             for (uint256 i = 0; i < delegatees.length; i++)
-                franchisers[i] = fund(delegatees[i], amounts[i]);
+                franchisers[i] = fund(delegatees[i], amounts[i], expiration);
         }
     }
 
@@ -105,6 +111,13 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
             for (uint256 i = 0; i < delegatees.length; i++)
                 recall(delegatees[i], tos[i]);
         }
+    }
+
+    /// @inheritdoc IFranchiserFactory
+    function expiredRecall(address owner, address delegatee) public {
+        Franchiser franchiser = getFranchiser(owner, delegatee);
+        if (block.timestamp < expirations[franchiser]) revert DelegateeNotExpired();
+        if (address(franchiser).isContract()) franchiser.recall(owner);
     }
 
     function permit(
@@ -133,12 +146,13 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
         address delegatee,
         uint256 amount,
         uint256 deadline,
+        uint256 expiration,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) external returns (Franchiser) {
         permit(amount, deadline, v, r, s);
-        return fund(delegatee, amount);
+        return fund(delegatee, amount, expiration);
     }
 
     /// @inheritdoc IFranchiserFactory
@@ -146,6 +160,7 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
         address[] calldata delegatees,
         uint256[] calldata amounts,
         uint256 deadline,
+        uint256 expiration,
         uint8 v,
         bytes32 r,
         bytes32 s
@@ -159,7 +174,7 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
         franchisers = new Franchiser[](delegatees.length);
         unchecked {
             for (uint256 i = 0; i < delegatees.length; i++)
-                franchisers[i] = fund(delegatees[i], amounts[i]);
+                franchisers[i] = fund(delegatees[i], amounts[i], expiration);
         }
     }
 }

--- a/src/FranchiserFactory.sol
+++ b/src/FranchiserFactory.sol
@@ -120,6 +120,17 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
         if (address(franchiser).isContract()) franchiser.recall(owner);
     }
 
+    /// @inheritdoc IFranchiserFactory
+    function expiredRecallMany(address[] calldata owners, address[] calldata delegatees) external {
+        if (delegatees.length != owners.length)
+            revert ArrayLengthMismatch(delegatees.length, owners.length);
+
+        unchecked {
+            for (uint256 i = 0; i < delegatees.length; i++)
+                expiredRecall(owners[i], delegatees[i]);
+        }
+    }
+
     function permit(
         uint256 amount,
         uint256 deadline,

--- a/src/FranchiserFactory.sol
+++ b/src/FranchiserFactory.sol
@@ -145,8 +145,8 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
     function permitAndFund(
         address delegatee,
         uint256 amount,
-        uint256 deadline,
         uint256 expiration,
+        uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s
@@ -159,8 +159,8 @@ contract FranchiserFactory is IFranchiserFactory, FranchiserImmutableState {
     function permitAndFundMany(
         address[] calldata delegatees,
         uint256[] calldata amounts,
-        uint256 deadline,
         uint256 expiration,
+        uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s

--- a/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
@@ -22,6 +22,11 @@ interface IFranchiserFactory is
     /// @return The Franchiser implementation contract.
     function franchiserImplementation() external view returns (Franchiser);
 
+    /// @notice Returns the `expiration` timestamp for a given `franchiser`.
+    /// @param franchiser The target `franchiser`.
+    /// @return The timestamp when the franchiser's voting power expires.
+    function expirations(Franchiser franchiser) external view returns (uint256);
+
     /// @notice Looks up the Franchiser associated with the `owner` and `delegatee`.
     /// @dev Returns the address of the Franchiser even it it does not yet exist,
     ///      thanks to CREATE2.
@@ -39,8 +44,9 @@ interface IFranchiserFactory is
     ///      If a Franchiser does not yet exist, one is created.
     /// @param delegatee The target `delegatee`.
     /// @param amount The amount of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @return franchiser The Franchiser contract.
-    function fund(address delegatee, uint256 amount)
+    function fund(address delegatee, uint256 amount, uint256 expiration)
         external
         returns (Franchiser franchiser);
 
@@ -48,8 +54,9 @@ interface IFranchiserFactory is
     /// @dev Requires the sender of the call to have approved this contract for sum of `amounts`.
     /// @param delegatees The target `delegatees`.
     /// @param amounts The amounts of `votingToken` to allocate.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @return franchisers The Franchiser contracts.
-    function fundMany(address[] calldata delegatees, uint256[] calldata amounts)
+    function fundMany(address[] calldata delegatees, uint256[] calldata amounts, uint256 expiration)
         external
         returns (Franchiser[] memory franchisers);
 
@@ -65,6 +72,13 @@ interface IFranchiserFactory is
     function recallMany(address[] calldata delegatees, address[] calldata tos)
         external;
 
+    /// @notice Recalls voting tokens from an expired delegatee back to the owner.
+    /// @dev Can be called by anyone, but only after the delegatee's expiration time has passed.
+    /// @dev Will revert with `DelegateeNotExpired` if called before expiration time.
+    /// @param owner The target `owner`.
+    /// @param delegatee The address of the delegatee whose tokens should be recalled.
+    function expiredRecall(address owner, address delegatee) external;
+
     /// @notice Funds the Franchiser contract associated with the `delegatee`
     ///         using a signature.
     /// @dev The signature must have been produced by the sender of the call.
@@ -72,6 +86,7 @@ interface IFranchiserFactory is
     /// @param delegatee The target `delegatee`.
     /// @param amount The amount of `votingToken` to allocate.
     /// @param deadline A timestamp which the current timestamp must be less than or equal to.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
     /// @param s Must produce valid secp256k1 signature from the holder along with `v` and `r`.
@@ -80,6 +95,7 @@ interface IFranchiserFactory is
         address delegatee,
         uint256 amount,
         uint256 deadline,
+        uint256 expiration,
         uint8 v,
         bytes32 r,
         bytes32 s
@@ -90,6 +106,7 @@ interface IFranchiserFactory is
     /// @param delegatees The target `delegatees`.
     /// @param amounts The amounts of `votingToken` to allocate.
     /// @param deadline A timestamp which the current timestamp must be less than or equal to.
+    /// @param expiration The timestamp when the delegatee's voting power expires.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
     /// @param s Must produce valid secp256k1 signature from the holder along with `v` and `r`.
@@ -98,6 +115,7 @@ interface IFranchiserFactory is
         address[] calldata delegatees,
         uint256[] calldata amounts,
         uint256 deadline,
+        uint256 expiration,
         uint8 v,
         bytes32 r,
         bytes32 s

--- a/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
@@ -85,8 +85,8 @@ interface IFranchiserFactory is
     ///      If a Franchiser does not yet exist, one is created.
     /// @param delegatee The target `delegatee`.
     /// @param amount The amount of `votingToken` to allocate.
-    /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param expiration The timestamp when the delegatee's voting power expires.
+    /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
     /// @param s Must produce valid secp256k1 signature from the holder along with `v` and `r`.
@@ -105,8 +105,8 @@ interface IFranchiserFactory is
     /// @dev The permit must be for the sum of `amounts`.
     /// @param delegatees The target `delegatees`.
     /// @param amounts The amounts of `votingToken` to allocate.
-    /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param expiration The timestamp when the delegatee's voting power expires.
+    /// @param deadline A timestamp which the current timestamp must be less than or equal to.
     /// @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`.
     /// @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`.
     /// @param s Must produce valid secp256k1 signature from the holder along with `v` and `r`.

--- a/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
@@ -79,6 +79,11 @@ interface IFranchiserFactory is
     /// @param delegatee The address of the delegatee whose tokens should be recalled.
     function expiredRecall(address owner, address delegatee) external;
 
+    /// @notice Calls expiredRecall many times.
+    /// @param owners The target `owners`.
+    /// @param delegatees The target `delegatees`.
+    function expiredRecallMany(address[] calldata owners, address[] calldata delegatees) external;
+
     /// @notice Funds the Franchiser contract associated with the `delegatee`
     ///         using a signature.
     /// @dev The signature must have been produced by the sender of the call.

--- a/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactory.sol
@@ -94,8 +94,8 @@ interface IFranchiserFactory is
     function permitAndFund(
         address delegatee,
         uint256 amount,
-        uint256 deadline,
         uint256 expiration,
+        uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s
@@ -114,8 +114,8 @@ interface IFranchiserFactory is
     function permitAndFundMany(
         address[] calldata delegatees,
         uint256[] calldata amounts,
-        uint256 deadline,
         uint256 expiration,
+        uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s

--- a/src/interfaces/FranchiserFactory/IFranchiserFactoryErrors.sol
+++ b/src/interfaces/FranchiserFactory/IFranchiserFactoryErrors.sol
@@ -7,4 +7,10 @@ interface IFranchiserFactoryErrors {
     /// @param length0 The length of the first array argument.
     /// @param length1 The length of the second array argument.
     error ArrayLengthMismatch(uint256 length0, uint256 length1);
+
+    /// @notice Thrown when attempting to set an expiration timestamp that is in the past
+    error InvalidExpiration();
+
+    /// @notice Thrown when attempting to recall tokens from a delegatee before their delegation has expired
+    error DelegateeNotExpired();
 }

--- a/test/Franchiser.t.sol
+++ b/test/Franchiser.t.sol
@@ -405,6 +405,7 @@ contract FranchiserTest is Test, IFranchiserErrors, IFranchiserEvents {
         vm.assume(_validActorAddress(_delegatee));
         vm.assume(_validActorAddress(_attacker));
         vm.assume(_validActorAddress(_delegator));
+        vm.assume(_attacker != _delegator);
         _amount = bound(_amount, 4, 100_000_000e18);
         votingToken.mint(_delegator, _amount);
 

--- a/test/FranchiserFactory.t.sol
+++ b/test/FranchiserFactory.t.sol
@@ -405,7 +405,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
             votingToken.getPermitSignature(vm, 0xa11ce, address(franchiserFactory), 100);
         votingToken.mint(owner, 100);
         vm.prank(owner);
-        Franchiser franchiser = franchiserFactory.permitAndFund(Utils.bob, 100, deadline, safeFutureExpiration, v, r, s);
+        Franchiser franchiser = franchiserFactory.permitAndFund(Utils.bob, 100, safeFutureExpiration, deadline, v, r, s);
 
         assertEq(votingToken.balanceOf(address(franchiser)), 100);
         assertEq(votingToken.getVotes(Utils.bob), 100);
@@ -414,10 +414,10 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
     function testPermitAndFundManyRevertsArrayLengthMismatch() public {
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 0, 1));
-        franchiserFactory.permitAndFundMany(new address[](0), new uint256[](1), 0, safeFutureExpiration, 0, 0, 0);
+        franchiserFactory.permitAndFundMany(new address[](0), new uint256[](1), safeFutureExpiration, 0, 0, 0, 0);
 
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 1, 0));
-        franchiserFactory.permitAndFundMany(new address[](1), new uint256[](0), 0, safeFutureExpiration, 0, 0, 0);
+        franchiserFactory.permitAndFundMany(new address[](1), new uint256[](0), safeFutureExpiration, 0, 0, 0, 0);
     }
 
     // fails because of overflow
@@ -443,7 +443,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         amounts[1] = 50;
 
         vm.prank(owner);
-        Franchiser[] memory franchisers = franchiserFactory.permitAndFundMany(delegatees, amounts, deadline, safeFutureExpiration, v, r, s);
+        Franchiser[] memory franchisers = franchiserFactory.permitAndFundMany(delegatees, amounts, safeFutureExpiration, deadline, v, r, s);
 
         assertEq(votingToken.balanceOf(address(franchisers[0])), 50);
         assertEq(votingToken.balanceOf(address(franchisers[1])), 50);

--- a/test/FranchiserFactory.t.sol
+++ b/test/FranchiserFactory.t.sol
@@ -400,7 +400,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         franchiserFactory.expiredRecall(_owner, _delegatee);
     }
 
-    function testExpiredRecallMany(
+    function testFuzz_ExpiredRecallMany(
         address _owner,
         address _delegatee1,
         address _delegatee2,

--- a/test/FranchiserFactory.t.sol
+++ b/test/FranchiserFactory.t.sol
@@ -15,6 +15,8 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
     VotingTokenConcrete private votingToken;
     FranchiserFactory private franchiserFactory;
 
+    uint safeFutureExpiration = block.timestamp + 1 weeks;
+
     function setUp() public {
         votingToken = new VotingTokenConcrete();
         franchiserFactory = new FranchiserFactory(IVotingToken(address(votingToken)));
@@ -47,24 +49,25 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         vm.expectEmit(true, true, true, true, address(expectedFranchiser));
         emit Initialized(address(franchiserFactory), Utils.alice, Utils.bob, 8);
         vm.prank(Utils.alice);
-        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 0);
+        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 0, safeFutureExpiration);
 
         assertEq(address(expectedFranchiser), address(franchiser));
         assertEq(franchiser.owner(), address(franchiserFactory));
         assertEq(franchiser.delegatee(), Utils.bob);
         assertEq(votingToken.delegates(address(franchiser)), Utils.bob);
+        assertEq(franchiserFactory.expirations(franchiser), safeFutureExpiration);
     }
 
     function testFundCanCallTwice() public {
         vm.startPrank(Utils.alice);
-        franchiserFactory.fund(Utils.bob, 0);
-        franchiserFactory.fund(Utils.bob, 0);
+        franchiserFactory.fund(Utils.bob, 0, safeFutureExpiration);
+        franchiserFactory.fund(Utils.bob, 0, safeFutureExpiration);
         vm.stopPrank();
     }
 
     function testFundNonZeroRevertsTRANSFER_FROM_FAILED() public {
         vm.expectRevert(bytes("TRANSFER_FROM_FAILED"));
-        franchiserFactory.fund(Utils.bob, 100);
+        franchiserFactory.fund(Utils.bob, 100, safeFutureExpiration);
     }
 
     function testFundNonZero() public {
@@ -72,19 +75,21 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(Utils.alice);
         votingToken.approve(address(franchiserFactory), 100);
-        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 100);
+        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 100, safeFutureExpiration);
         vm.stopPrank();
 
         assertEq(votingToken.balanceOf(address(franchiser)), 100);
         assertEq(votingToken.getVotes(Utils.bob), 100);
+        assertEq(franchiserFactory.expirations(franchiser), safeFutureExpiration);
     }
 
-    function testFuzz_FundBalancesAndVotingPowerUpdated(address _delegator, address _delegatee, uint256 _amount)
+    function testFuzz_FundBalances_VotingPower_ExpirationUpdated(address _delegator, address _delegatee, uint256 _amount, uint256 _expiration)
         public
     {
         vm.assume(_validActorAddress(_delegator));
         vm.assume(_delegatee != address(0));
         _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp, type(uint).max);
         Franchiser expectedFranchiser = franchiserFactory.getFranchiser(_delegator, _delegatee);
         uint256 _delegateeVotesBefore = votingToken.getVotes(_delegatee);
         uint256 _franchiserBalanceBefore = votingToken.balanceOf(address(expectedFranchiser));
@@ -94,12 +99,65 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(_delegator);
         votingToken.approve(address(franchiserFactory), _amount);
-        Franchiser franchiser = franchiserFactory.fund(_delegatee, _amount);
+        Franchiser franchiser = franchiserFactory.fund(_delegatee, _amount, _expiration);
         vm.stopPrank();
 
         assertEq(votingToken.balanceOf(address(franchiser)), _franchiserBalanceBefore + _amount);
         assertEq(votingToken.getVotes(_delegatee), _delegateeVotesBefore + _amount);
         assertEq(votingToken.balanceOf(_delegator), _delegatorBalanceBefore - _amount);
+        assertEq(franchiserFactory.expirations(franchiser), _expiration);
+    }
+
+    function testFuzz_Fund_OverwritesExpiration_BeforeExpiry(address _owner, address _delegatee, uint256 _amount, uint256 _expiration, uint256 _warpTime, uint256 _newExpiration) public {
+        vm.assume(_validActorAddress(_owner));
+        vm.assume(_delegatee != address(0));
+
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp + 1 days, type(uint).max);
+        _warpTime = bound(_warpTime, block.timestamp, _expiration - 1);
+        _newExpiration = bound(_newExpiration, _warpTime, type(uint).max);
+
+        votingToken.mint(_owner, _amount);
+
+        vm.startPrank(_owner);
+        votingToken.approve(address(franchiserFactory), _amount);
+        Franchiser franchiser = franchiserFactory.fund(_delegatee, _amount, _expiration);
+        assertEq(_expiration, franchiserFactory.expirations(franchiser));
+
+        vm.warp(_warpTime);
+        votingToken.mint(_owner, _amount);
+
+        votingToken.approve(address(franchiserFactory), _amount);
+        Franchiser newFranchiser = franchiserFactory.fund(_delegatee, _amount, _newExpiration);
+        assertEq(address(newFranchiser), address(franchiser));
+        assertEq(_newExpiration, franchiserFactory.expirations(newFranchiser));
+        vm.stopPrank();
+    }
+
+    function testFuzz_Fund_OverwritesExpiration_AfterExpiry(address _owner, address _delegatee, uint256 _amount, uint256 _expiration, uint256 _warpTime, uint256 _newExpiration) public {
+        vm.assume(_validActorAddress(_owner));
+        vm.assume(_delegatee != address(0));
+
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp + 1 days, type(uint).max);
+        _warpTime = bound(_warpTime, _expiration, type(uint).max);
+        _newExpiration = bound(_newExpiration, _warpTime, type(uint).max);
+
+        votingToken.mint(_owner, _amount);
+
+        vm.startPrank(_owner);
+        votingToken.approve(address(franchiserFactory), _amount);
+        Franchiser franchiser = franchiserFactory.fund(_delegatee, _amount, _expiration);
+        assertEq(_expiration, franchiserFactory.expirations(franchiser));
+
+        vm.warp(_warpTime);
+        votingToken.mint(_owner, _amount);
+
+        votingToken.approve(address(franchiserFactory), _amount);
+        Franchiser newFranchiser = franchiserFactory.fund(_delegatee, _amount, _newExpiration);
+        assertEq(address(newFranchiser), address(franchiser));
+        assertEq(_newExpiration, franchiserFactory.expirations(newFranchiser));
+        vm.stopPrank();
     }
 
     function testFuzz_FundFailsWhenDelegateeIsAddressZero(address _delegator, uint256 _amount) public {
@@ -112,7 +170,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         vm.startPrank(_delegator);
         votingToken.approve(address(franchiserFactory), _amount);
         vm.expectRevert(IFranchiserErrors.NoDelegatee.selector);
-        franchiserFactory.fund(_delegatee, _amount);
+        franchiserFactory.fund(_delegatee, _amount, safeFutureExpiration);
         vm.stopPrank();
     }
 
@@ -130,16 +188,30 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         vm.startPrank(_delegator);
         votingToken.approve(address(franchiserFactory), _amount);
         vm.expectRevert(bytes("TRANSFER_FROM_FAILED"));
-        franchiserFactory.fund(_delegatee, _amount);
+        franchiserFactory.fund(_delegatee, _amount, safeFutureExpiration);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_ExpirationLessThanBlockTimestamp(address _delegator, address _delegatee, uint256 _amount, uint256 _expiration) public {
+        vm.assume(_validActorAddress(_delegator));
+        vm.assume(_delegatee != address(0));
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, 0, block.timestamp - 1);
+        votingToken.mint(_delegator, _amount);
+
+        vm.startPrank(_delegator);
+        votingToken.approve(address(franchiserFactory), _amount);
+        vm.expectRevert(IFranchiserFactoryErrors.InvalidExpiration.selector);
+        franchiserFactory.fund(_delegatee, _amount, _expiration);
         vm.stopPrank();
     }
 
     function testFundManyRevertsArrayLengthMismatch() public {
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 0, 1));
-        franchiserFactory.fundMany(new address[](0), new uint256[](1));
+        franchiserFactory.fundMany(new address[](0), new uint256[](1), safeFutureExpiration);
 
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 1, 0));
-        franchiserFactory.fundMany(new address[](1), new uint256[](0));
+        franchiserFactory.fundMany(new address[](1), new uint256[](0), safeFutureExpiration);
     }
 
     function testFundMany() public {
@@ -155,11 +227,13 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(Utils.alice);
         votingToken.approve(address(franchiserFactory), 100);
-        Franchiser[] memory franchisers = franchiserFactory.fundMany(delegatees, amounts);
+        Franchiser[] memory franchisers = franchiserFactory.fundMany(delegatees, amounts, safeFutureExpiration);
         vm.stopPrank();
 
         assertEq(votingToken.balanceOf(address(franchisers[0])), 50);
         assertEq(votingToken.balanceOf(address(franchisers[1])), 50);
+        assertEq(franchiserFactory.expirations(franchisers[0]), safeFutureExpiration);
+        assertEq(franchiserFactory.expirations(franchisers[1]), safeFutureExpiration);
     }
 
     function testRecallZero() public {
@@ -171,13 +245,14 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(Utils.alice);
         votingToken.approve(address(franchiserFactory), 100);
-        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 100);
+        Franchiser franchiser = franchiserFactory.fund(Utils.bob, 100, safeFutureExpiration);
         franchiserFactory.recall(Utils.bob, Utils.alice);
         vm.stopPrank();
 
         assertEq(votingToken.balanceOf(address(franchiser)), 0);
         assertEq(votingToken.balanceOf(Utils.alice), 100);
         assertEq(votingToken.getVotes(Utils.bob), 0);
+        assertEq(franchiserFactory.expirations(franchiser), safeFutureExpiration);
     }
 
     function testFuzz_RecallDelegatorBalanceUpdated(address _delegator, address _delegatee, uint256 _amount) public {
@@ -189,7 +264,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(_delegator);
         votingToken.approve(address(franchiserFactory), _amount);
-        franchiserFactory.fund(_delegatee, _amount);
+        franchiserFactory.fund(_delegatee, _amount, safeFutureExpiration);
 
         uint256 _delegatorBalanceBeforeRecall = votingToken.balanceOf(_delegator);
         franchiserFactory.recall(_delegatee, _delegator);
@@ -219,8 +294,8 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
 
         vm.startPrank(Utils.alice);
         votingToken.approve(address(franchiserFactory), 100);
-        franchiserFactory.fund(Utils.bob, 50);
-        franchiserFactory.fund(Utils.carol, 50);
+        franchiserFactory.fund(Utils.bob, 50, safeFutureExpiration);
+        franchiserFactory.fund(Utils.carol, 50, safeFutureExpiration);
         franchiserFactory.recallMany(delegatees, tos);
         vm.stopPrank();
 
@@ -228,7 +303,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
     }
 
     function testRecallGasWorstCase() public {
-        Utils.nestMaximum(vm, votingToken, franchiserFactory);
+        Utils.nestMaximum(vm, votingToken, franchiserFactory, safeFutureExpiration);
         vm.prank(address(1));
         uint256 gasBefore = gasleft();
         franchiserFactory.recall(address(2), address(1));
@@ -241,23 +316,108 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         assertEq(votingToken.balanceOf(address(1)), 64);
     }
 
+    function testFuzz_ExpiredRecall_Owner_BalanceUpdated(address _owner, address _delegatee, uint256 _amount, uint256 _expiration, address _expiredRecallCaller, uint _recallTimestamp) public {
+        vm.assume(_validActorAddress(_owner));
+        vm.assume(_delegatee != address(0));
+
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp, type(uint).max);
+        _recallTimestamp = bound(_recallTimestamp, _expiration, type(uint).max);
+
+        votingToken.mint(_owner, _amount);
+
+        vm.startPrank(_owner);
+        votingToken.approve(address(franchiserFactory), _amount);
+        franchiserFactory.fund(_delegatee, _amount, _expiration);
+        vm.stopPrank();
+        vm.warp(_recallTimestamp);
+        uint256 _ownerBalanceBeforeRecall = votingToken.balanceOf(_owner);
+
+        vm.prank(_expiredRecallCaller);
+        franchiserFactory.expiredRecall(_owner, _delegatee);
+
+        assertEq(votingToken.balanceOf(_owner), _ownerBalanceBeforeRecall + _amount);
+    }
+
+    function testFuzz_ExpiredRecall_NestedSubDelegatees_BalancesUpdated(address _owner, address _delegatee, address _subDelegatee1, address _subDelegatee2, uint256 _expiration, uint256 _recallTimestamp, address _expiredRecallCaller, uint256 _amount
+    ) public {
+        vm.assume(_validActorAddress(_owner));
+        vm.assume(_validActorAddress(_delegatee));
+        vm.assume(_validActorAddress(_subDelegatee1));
+        vm.assume(_subDelegatee2 != address(0));
+
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp, type(uint).max);
+        _recallTimestamp = bound(_recallTimestamp, _expiration, type(uint).max);
+
+        votingToken.mint(_owner, _amount);
+
+        vm.startPrank(_owner);
+        votingToken.approve(address(franchiserFactory), _amount);
+        Franchiser franchiser = franchiserFactory.fund(_delegatee, _amount, _expiration);
+        vm.stopPrank();
+
+        // sub-delegate one-fourth of the amount to each sub-delegatee
+        vm.prank(_delegatee);
+        Franchiser _subFranchiser1 = franchiser.subDelegate(_subDelegatee1, _amount / 4);
+        assertEq(votingToken.balanceOf(address(franchiser)), _amount  - _amount / 4);
+        assertEq(votingToken.balanceOf(address(_subFranchiser1)), _amount / 4);
+
+        vm.prank(_subDelegatee1);
+        Franchiser _subFranchiser2 = _subFranchiser1.subDelegate(_subDelegatee2, _amount / 4);
+        assertEq(votingToken.balanceOf(address(_subFranchiser1)), 0);
+        assertEq(votingToken.balanceOf(address(_subFranchiser2)), _amount / 4);
+
+        vm.warp(_recallTimestamp);
+
+        vm.prank(_expiredRecallCaller);
+        franchiserFactory.expiredRecall(_owner, _delegatee);
+        assertEq(votingToken.balanceOf(address(franchiser)), 0);
+        assertEq(votingToken.balanceOf(address(_subFranchiser1)), 0);
+        assertEq(votingToken.balanceOf(address(_subFranchiser2)), 0);
+        assertEq(votingToken.balanceOf(_owner), _amount);
+    }
+
+    function testFuzz_RevertIf_ExpiredRecall_CalledBeforeExpiration(address _owner, address _delegatee, uint256 _amount, uint256 _expiration, address _expiredRecallCaller, uint _recallTimestamp) public {
+        vm.assume(_validActorAddress(_owner));
+        vm.assume(_delegatee != address(0));
+
+        _amount = _boundAmount(_amount);
+        _expiration = bound(_expiration, block.timestamp + 1 hours, type(uint).max);
+        _recallTimestamp = bound(_recallTimestamp, block.timestamp, _expiration - 1);
+
+        votingToken.mint(_owner, _amount);
+
+        vm.startPrank(_owner);
+        votingToken.approve(address(franchiserFactory), _amount);
+        franchiserFactory.fund(_delegatee, _amount, _expiration);
+        vm.stopPrank();
+
+        vm.warp(_recallTimestamp);
+
+        vm.prank(_expiredRecallCaller);
+        vm.expectRevert(abi.encodeWithSelector(DelegateeNotExpired.selector));
+        franchiserFactory.expiredRecall(_owner, _delegatee);
+    }
+
     function testPermitAndFund() public {
         (address owner, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
             votingToken.getPermitSignature(vm, 0xa11ce, address(franchiserFactory), 100);
         votingToken.mint(owner, 100);
         vm.prank(owner);
-        Franchiser franchiser = franchiserFactory.permitAndFund(Utils.bob, 100, deadline, v, r, s);
+        Franchiser franchiser = franchiserFactory.permitAndFund(Utils.bob, 100, deadline, safeFutureExpiration, v, r, s);
 
         assertEq(votingToken.balanceOf(address(franchiser)), 100);
         assertEq(votingToken.getVotes(Utils.bob), 100);
-    }
+        assertEq(franchiserFactory.expirations(franchiser), safeFutureExpiration);
+        }
 
     function testPermitAndFundManyRevertsArrayLengthMismatch() public {
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 0, 1));
-        franchiserFactory.permitAndFundMany(new address[](0), new uint256[](1), 0, 0, 0, 0);
+        franchiserFactory.permitAndFundMany(new address[](0), new uint256[](1), 0, safeFutureExpiration, 0, 0, 0);
 
         vm.expectRevert(abi.encodeWithSelector(ArrayLengthMismatch.selector, 1, 0));
-        franchiserFactory.permitAndFundMany(new address[](1), new uint256[](0), 0, 0, 0, 0);
+        franchiserFactory.permitAndFundMany(new address[](1), new uint256[](0), 0, safeFutureExpiration, 0, 0, 0);
     }
 
     // fails because of overflow
@@ -266,7 +426,7 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         amounts[0] = type(uint256).max;
         amounts[1] = 1;
 
-        franchiserFactory.permitAndFundMany(new address[](2), amounts, 0, 0, 0, 0);
+        franchiserFactory.permitAndFundMany(new address[](2), amounts, 0, safeFutureExpiration, 0, 0, 0);
     }
 
     function testPermitAndFundMany() public {
@@ -283,9 +443,11 @@ contract FranchiserFactoryTest is Test, IFranchiserFactoryErrors, IFranchiserEve
         amounts[1] = 50;
 
         vm.prank(owner);
-        Franchiser[] memory franchisers = franchiserFactory.permitAndFundMany(delegatees, amounts, deadline, v, r, s);
+        Franchiser[] memory franchisers = franchiserFactory.permitAndFundMany(delegatees, amounts, deadline, safeFutureExpiration, v, r, s);
 
         assertEq(votingToken.balanceOf(address(franchisers[0])), 50);
         assertEq(votingToken.balanceOf(address(franchisers[1])), 50);
+        assertEq(franchiserFactory.expirations(franchisers[0]), safeFutureExpiration);
+        assertEq(franchiserFactory.expirations(franchisers[1]), safeFutureExpiration);
     }
 }

--- a/test/FranchiserLens.t.sol
+++ b/test/FranchiserLens.t.sol
@@ -15,6 +15,8 @@ contract FranchiserLensTest is Test {
     FranchiserFactory private franchiserFactory;
     FranchiserLens private franchiserLens;
 
+    uint safeFutureExpiration = block.timestamp + 1 weeks;
+
     function setUp() public {
         votingToken = new VotingTokenConcrete();
         franchiserFactory = new FranchiserFactory(
@@ -38,7 +40,8 @@ contract FranchiserLensTest is Test {
             1,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -66,7 +69,8 @@ contract FranchiserLensTest is Test {
             2,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -106,7 +110,8 @@ contract FranchiserLensTest is Test {
             5,
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.Delegation memory rootDelegation = franchiserLens
@@ -171,7 +176,8 @@ contract FranchiserLensTest is Test {
         Franchiser[][5] memory franchisers = Utils.nestMaximum(
             vm,
             votingToken,
-            franchiserFactory
+            franchiserFactory,
+            safeFutureExpiration
         );
 
         IFranchiserLens.DelegationWithVotes[][]

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -43,8 +43,10 @@ contract IntegrationTest is Test {
         IGovernorBravo(0x408ED6354d4973f66138C91495F2f2FCbd8724C3);
 
     FranchiserFactory private franchiserFactory;
+    uint safeFutureExpiration;
 
     function setUp() public {
+        safeFutureExpiration = block.timestamp + 1 weeks;
         vm.startPrank(address(0));
         franchiserFactory = new FranchiserFactory(UNI);
         // fund the timelock with 1 ETH to send txs
@@ -58,7 +60,7 @@ contract IntegrationTest is Test {
 
         vm.startPrank(address(TIMELOCK));
         UNI.approve(address(franchiserFactory), quorumVotes);
-        franchiserFactory.fund(Utils.alice, quorumVotes);
+        franchiserFactory.fund(Utils.alice, quorumVotes, safeFutureExpiration);
         vm.stopPrank();
 
         // encode a call to send 1 wei of UNI to alice

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -21,7 +21,8 @@ library Utils {
         uint256 levels,
         Vm vm,
         VotingTokenConcrete votingToken,
-        FranchiserFactory franchiserFactory
+        FranchiserFactory franchiserFactory,
+        uint256 expiration
     ) internal returns (Franchiser[5] memory franchisers) {
         assert(levels != 0);
         assert(levels <= 5);
@@ -35,7 +36,7 @@ library Utils {
         votingToken.mint(alice, 1);
         vm.startPrank(alice);
         votingToken.approve(address(franchiserFactory), 1);
-        franchisers[0] = franchiserFactory.fund(delegatees[0], 1);
+        franchisers[0] = franchiserFactory.fund(delegatees[0], 1, expiration);
         vm.stopPrank();
 
         unchecked {
@@ -60,7 +61,8 @@ library Utils {
     function nestMaximum(
         Vm vm,
         VotingTokenConcrete votingToken,
-        FranchiserFactory franchiserFactory
+        FranchiserFactory franchiserFactory,
+        uint256 expiration
     ) internal returns (Franchiser[][5] memory franchisers) {
         assert(franchiserFactory.INITIAL_MAXIMUM_SUBDELEGATEES() == 8);
         assert(
@@ -78,7 +80,7 @@ library Utils {
         votingToken.mint(address(1), 64);
         vm.startPrank(address(1));
         votingToken.approve(address(franchiserFactory), 64);
-        franchisers[0][0] = franchiserFactory.fund(nextDelegatee, 64);
+        franchisers[0][0] = franchiserFactory.fund(nextDelegatee, 64, expiration);
         vm.stopPrank();
 
         nextDelegatee = incrementNextDelegatee(nextDelegatee);

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -13,6 +13,8 @@ contract FranchiserFactoryHandler is Test {
     using EnumerableSet for EnumerableSet.AddressSet;
     using Address for address;
 
+    uint safeFutureExpiration = block.timestamp + 1 weeks;
+
     FranchiserFactory public factory;
     Franchiser public franchiser;
     Franchiser public subDelegatedFranchiser;
@@ -207,7 +209,7 @@ contract FranchiserFactoryHandler is Test {
         votingToken.mint(_delegator, _amount);
         vm.startPrank(_delegator);
         votingToken.approve(address(factory), _amount);
-        franchiser = factory.fund(_delegatee, _amount);
+        franchiser = factory.fund(_delegatee, _amount, safeFutureExpiration);
         vm.stopPrank();
 
         // add the created franchiser to the fundedFranchisers AddressSet for tracking totals invariants
@@ -244,7 +246,7 @@ contract FranchiserFactoryHandler is Test {
 
         // clear the storage of the lastFundedFranchisersArray and create a new one with call to fundMany
         delete lastFundedFranchisersArray;
-        lastFundedFranchisersArray = factory.fundMany(_delegatees, _amountsForFundMany);
+        lastFundedFranchisersArray = factory.fundMany(_delegatees, _amountsForFundMany, safeFutureExpiration);
         vm.stopPrank();
 
         // add the delegator to the delegators AddressSets for tracking totals invariants
@@ -323,7 +325,7 @@ contract FranchiserFactoryHandler is Test {
         votingToken.mint(_delegator, _amount);
 
         vm.prank(_delegator);
-        franchiser = factory.permitAndFund(_delegatee, _amount, _deadline, _v, _r, _s);
+        franchiser = factory.permitAndFund(_delegatee, _amount, _deadline, safeFutureExpiration, _v, _r, _s);
 
         // add the created franchiser to the fundedFranchisers AddressSet for tracking totals invariants
         _increaseFundedFranchiserAccountBalance(franchiser, _amount);
@@ -358,7 +360,7 @@ contract FranchiserFactoryHandler is Test {
 
         // clear the storage of the lastFundedFranchisersArray and create a new one with call to fundMany
         delete lastFundedFranchisersArray;
-        lastFundedFranchisersArray = factory.permitAndFundMany(_delegatees, _amountsForFundMany, _deadline, _v, _r, _s);
+        lastFundedFranchisersArray = factory.permitAndFundMany(_delegatees, _amountsForFundMany, _deadline, safeFutureExpiration, _v, _r, _s);
         vm.stopPrank();
 
         // add the delegator to the delegators AddressSet for tracking totals invariants


### PR DESCRIPTION
### Contract Changes
- Added `expirations` mapping in `FranchiserFactory` to track expiration timestamps for each franchiser
- Modified `fund()` and `fundMany()` functions to accept an `expiration` parameter
- Added `expiredRecall()` function to allow anyone to recall expired delegations
- Added new error types: `InvalidExpiration` and `DelegateeNotExpired`
- Updated all permit-related functions to include `expiration` parameter

### Test Coverage
- Added test for expiration functionality:
  - Basic expiration setting and validation
  - Expired recall mechanics
  - Nested subdelegatee behavior with expirations