### PR TITLE
Add `factory_expiredRecall` and `factory_expiredRecallMany` to Handler contract

### DIFF
--- a/.github/workflows/invariant-runs.yml
+++ b/.github/workflows/invariant-runs.yml
@@ -1,14 +1,10 @@
 name: test
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   workflow_dispatch:
 
 env:
-  FOUNDRY_PROFILE: ci
+  FOUNDRY_PROFILE: ci_invariant
 
 jobs:
   check:
@@ -33,19 +29,7 @@ jobs:
           forge build --sizes
         id: build
 
-      - name: Run Forge unit tests
-        run: |
-          forge test -vvv --no-match-contract "FranchiserFactoryInvariantTest|IntegrationTest"
-        id: unit-test
-
       - name: Run Forge invariant tests
         run: |
           forge test -vvv --match-contract FranchiserFactoryInvariantTest
         id: invariant-test
-
-      - name: Run Forge integration tests
-        env:
-          FORK_URL: ${{ secrets.FORK_URL }}
-        run: |
-          forge test -vvv --match-contract IntegrationTest --fork-url $FORK_URL
-        id: integration-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ bytecode_hash = "none"
 
 [profile.ci]
 fuzz = { runs = 500 }
-invariant = { runs = 50 }
+invariant = { runs = 50, depth = 1000 }
 
 [invariant]
 call_override = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,10 @@ bytecode_hash = "none"
 
 [profile.ci]
 fuzz = { runs = 500 }
-invariant = { runs = 50, depth = 1000 }
+invariant = { runs = 50 }
+
+[profile.ci_invariant]
+invariant = { runs = 50, depth = 500 }
 
 [invariant]
 call_override = false

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](11);
+        bytes4[] memory selectors = new bytes4[](12);
         selectors[0] = FranchiserFactoryHandler.factory_fund.selector;
         selectors[1] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
@@ -28,6 +28,7 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[8] = FranchiserFactoryHandler.franchiser_unSubDelegate.selector;
         selectors[9] = FranchiserFactoryHandler.franchiser_unSubDelegateMany.selector;
         selectors[10] = FranchiserFactoryHandler.franchiser_recall.selector;
+        selectors[11] = FranchiserFactoryHandler.factory_expiredRecall.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](13);
+        bytes4[] memory selectors = new bytes4[](14);
         selectors[0] = FranchiserFactoryHandler.factory_fund.selector;
         selectors[1] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
@@ -30,6 +30,7 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[10] = FranchiserFactoryHandler.franchiser_recall.selector;
         selectors[11] = FranchiserFactoryHandler.factory_expiredRecall.selector;
         selectors[12] = FranchiserFactoryHandler.factory_expiredRecallMany.selector;
+        selectors[13] = FranchiserFactoryHandler.factory_warpTime.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }
@@ -43,23 +44,14 @@ contract FranchiseFactoryInvariantTest is Test {
     }
 
     function invariant_Franchisers_and_recalled_balance_sum_matches_total_supply() external {
-        handler.callSummary();
-        assertEq(
-            token.totalSupply(),
-            handler.sumDelegatorsBalances() + handler.sumFundedFranchisersBalances()
-        );
+        assertEq(token.totalSupply(), handler.sumDelegatorsBalances() + handler.sumFundedFranchisersBalances());
     }
 
     function invariant_Total_funded_less_total_recalled_matches_franchisers_totals() external {
-        handler.callSummary();
-        assertEq(
-            handler.ghost_totalFunded() - handler.ghost_totalRecalled(),
-            handler.sumFundedFranchisersBalances()
-        );
+        assertEq(handler.ghost_totalFunded() - handler.ghost_totalRecalled(), handler.sumFundedFranchisersBalances());
     }
 
     function invariant_Franchiser_subdelegation_totals_are_correct() external {
-        handler.callSummary();
         handler.forEachFundedFranchiserAddress(this.assertFundedFranchisersSubDelegationBalancesAreCorrect);
     }
 
@@ -69,6 +61,9 @@ contract FranchiseFactoryInvariantTest is Test {
     }
 
     function assertFundedFranchisersSubDelegationBalancesAreCorrect(address _franchiser) external {
-        assertEq(handler.getTotalAmountDelegatedByFranchiser(_franchiser), handler.ghost_fundedFranchiserBalances(_franchiser));
+        assertEq(
+            handler.getTotalAmountDelegatedByFranchiser(_franchiser),
+            handler.ghost_fundedFranchiserBalances(_franchiser)
+        );
     }
 }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -16,7 +16,7 @@ contract FranchiseFactoryInvariantTest is Test {
         token = new VotingTokenConcrete();
         factory = new FranchiserFactory(IVotingToken(address(token)));
         handler = new FranchiserFactoryHandler(factory);
-        bytes4[] memory selectors = new bytes4[](12);
+        bytes4[] memory selectors = new bytes4[](13);
         selectors[0] = FranchiserFactoryHandler.factory_fund.selector;
         selectors[1] = FranchiserFactoryHandler.factory_fundMany.selector;
         selectors[2] = FranchiserFactoryHandler.factory_recall.selector;
@@ -29,6 +29,7 @@ contract FranchiseFactoryInvariantTest is Test {
         selectors[9] = FranchiserFactoryHandler.franchiser_unSubDelegateMany.selector;
         selectors[10] = FranchiserFactoryHandler.franchiser_recall.selector;
         selectors[11] = FranchiserFactoryHandler.factory_expiredRecall.selector;
+        selectors[12] = FranchiserFactoryHandler.factory_expiredRecallMany.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }

--- a/test/FranchiserFactory.invariants.t.sol
+++ b/test/FranchiserFactory.invariants.t.sol
@@ -7,7 +7,7 @@ import {FranchiserFactory} from "src/FranchiserFactory.sol";
 import {FranchiserFactoryHandler} from "test/handlers/FranchiserFactoryHandler.sol";
 import {VotingTokenConcrete} from "./VotingTokenConcrete.sol";
 
-contract FranchiseFactoryInvariantTest is Test {
+contract FranchiserFactoryInvariantTest is Test {
     FranchiserFactory factory;
     FranchiserFactoryHandler handler;
     VotingTokenConcrete token;

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -19,7 +19,7 @@ contract FranchiserFactoryHandler is Test {
     VotingTokenConcrete public votingToken;
 
     /// Maximum time offset for random warping
-    uint256 constant MAX_TIMESTAMP_OFFSET = 1 weeks;
+    uint256 constant MAX_TIMESTAMP_OFFSET = 500 days;
 
     // Struct for tracking the number of calls to each handler function
     struct CallCounts {
@@ -75,7 +75,10 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // function to decrease the funded franchiser balance mapping of an account by a given amount
-    function _decreaseFundedFranchiserAccountBalance(Franchiser _franchiser, uint256 _amount) private returns (Franchiser) {
+    function _decreaseFundedFranchiserAccountBalance(Franchiser _franchiser, uint256 _amount)
+        private
+        returns (Franchiser)
+    {
         // from the given franchiser, find the top-level franchiser that was orignally funded and is in the fundedFranchisers AddressSet
         while (_franchiser.owner() != address(factory)) {
             _franchiser = Franchiser(_franchiser.owner());
@@ -83,7 +86,9 @@ contract FranchiserFactoryHandler is Test {
 
         address _address = address(_franchiser);
         if (!fundedFranchisers.contains(_address)) {
-            console2.log("Funded franchiser address not not found in fundedFranchisers on _decreaseFundedFranchiserAccountBalance");
+            console2.log(
+                "Funded franchiser address not not found in fundedFranchisers on _decreaseFundedFranchiserAccountBalance"
+            );
             return _franchiser;
         }
         ghost_fundedFranchiserBalances[_address] -= _amount;
@@ -94,8 +99,7 @@ contract FranchiserFactoryHandler is Test {
         valid = (_address != address(0))
             && (
                 _address != address(votingToken) && (_address != address(factory))
-                    && (!fundedFranchisers.contains(_address)
-                    && (!subDelegatedFranchisers.contains(_address)))
+                    && (!fundedFranchisers.contains(_address) && (!subDelegatedFranchisers.contains(_address)))
             );
     }
 
@@ -114,7 +118,7 @@ contract FranchiserFactoryHandler is Test {
             vm.startPrank(address(_franchiser));
             address _subDelegatedFranchiser = address(_franchiser.getFranchiser(_franchiser.subDelegatees()[i]));
             vm.stopPrank();
-            totalAmount +=  getTotalAmountDelegatedByFranchiser(_subDelegatedFranchiser);
+            totalAmount += getTotalAmountDelegatedByFranchiser(_subDelegatedFranchiser);
         }
     }
 
@@ -124,7 +128,11 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // function that takes an array of addresses as a parameter and returns an array with duplicates removed
-    function _removeDuplicatesOrMatchingAddress(address[] memory _addresses, address _addressToRemove) internal pure returns (address[] memory) {
+    function _removeDuplicatesOrMatchingAddress(address[] memory _addresses, address _addressToRemove)
+        internal
+        pure
+        returns (address[] memory)
+    {
         if (_addresses.length == 0) {
             return _addresses;
         }
@@ -152,43 +160,12 @@ contract FranchiserFactoryHandler is Test {
         return _uniqueAddresses;
     }
 
-    /// function that computes a random int256 timestamp offset that can be either positive or negative
-    function _warpAroundExpiration(uint256 expiration) internal returns (int256 timestampOffset) {
-        console2.log("Current timestamp:", block.timestamp);
-        vm.roll(block.number + 1);  // Advance block for new randomness
+    /// Handler function to advance time randomly up to MAX_EXPIRATION_WARP
+    function factory_warpTime(uint256 _offset) external countCall("factory_warpTime") {
+        _offset = bound(_offset, 0, MAX_TIMESTAMP_OFFSET);
 
-        bytes32 entropy = keccak256(abi.encodePacked(
-            block.timestamp,
-            block.number,
-            MAX_TIMESTAMP_OFFSET,
-            msg.sender
-        ));
-
-        // Generate random magnitude and sign
-        uint256 offsetMagnitude = uint256(keccak256(abi.encodePacked(entropy, "offsetMagnitude"))) % MAX_TIMESTAMP_OFFSET;
-        bool isNegative = uint256(keccak256(abi.encodePacked(entropy, "isNegative"))) % 2 == 1;
-
-        // Compute the signed offset
-        timestampOffset =  isNegative ? -int256(offsetMagnitude) : int256(offsetMagnitude);
-
-        console2.log("Magnitude:", offsetMagnitude);
-        console2.log("isNegative:", isNegative);
-        console2.log("Final offset:", timestampOffset);
-
-        // Compute and validate the new timestamp
-        uint256 newTimestamp;
-        if (timestampOffset >= 0) {
-            require(expiration <= type(uint256).max - uint256(timestampOffset), "Timestamp overflow");
-            newTimestamp = expiration + uint256(timestampOffset);
-        } else {
-            require(expiration >= uint256(-timestampOffset), "Timestamp underflow");
-            newTimestamp = expiration - uint256(-timestampOffset);
-        }
-
-        // Apply the new timestamp
-        vm.warp(newTimestamp);
-        console2.log("New timestamp:", block.timestamp);
-        return timestampOffset;
+        // Warp to new timestamp
+        vm.warp(vm.getBlockTimestamp() + _offset);
     }
 
     // public function (callable by invariant tests) to get the sum of the total amount delegated by all funded franchisers
@@ -227,10 +204,11 @@ contract FranchiserFactoryHandler is Test {
         }
     }
 
-    function _selectFranchiserForSubDelegation(
-        uint256 _franchiserIndex,
-        bool _treeBuildDesired
-    ) internal view returns (Franchiser _selectedFranchiser) {
+    function _selectFranchiserForSubDelegation(uint256 _franchiserIndex, bool _treeBuildDesired)
+        internal
+        view
+        returns (Franchiser _selectedFranchiser)
+    {
         _selectedFranchiser = _selectFranchiser(_franchiserIndex, _treeBuildDesired);
         if (_selectedFranchiser.subDelegatees().length >= _selectedFranchiser.maximumSubDelegatees()) {
             console2.log("Warning::: Franchiser has reached maximum sub-delegatees");
@@ -243,7 +221,12 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // Invariant Handler functions for FranchiserFactory contract
-    function factory_fund(address _delegator, address _delegatee, uint256 _amount, uint256 _expiration) external countCall("factory_fund") {
+    function factory_fund(address _delegator, address _delegatee, uint256 _amount, uint256 _expiration)
+        external
+        countCall("factory_fund")
+    {
+        console2.log("factory_fund");
+        _expiration = bound(_expiration, vm.getBlockTimestamp(), vm.getBlockTimestamp() + MAX_TIMESTAMP_OFFSET);
         vm.assume(_validActorAddress(_delegator));
         _amount = _boundAmount(_amount);
         votingToken.mint(_delegator, _amount);
@@ -263,10 +246,13 @@ contract FranchiserFactoryHandler is Test {
         delegatees.add(_delegatee);
     }
 
-    function factory_fundMany(address _delegator, address[] memory _rawDelegatees, uint256 _baseAmount, uint256 _expiration)
-        external
-        countCall("factory_fundMany")
-    {
+    function factory_fundMany(
+        address _delegator,
+        address[] memory _rawDelegatees,
+        uint256 _baseAmount,
+        uint256 _expiration
+    ) external countCall("factory_fundMany") {
+        _expiration = bound(_expiration, vm.getBlockTimestamp(), vm.getBlockTimestamp() + MAX_TIMESTAMP_OFFSET);
         address[] memory _delegatees = _removeDuplicatesOrMatchingAddress(_rawDelegatees, address(0));
         uint256 _numberOfDelegatees = _delegatees.length;
         _baseAmount = _boundAmount(_baseAmount);
@@ -296,7 +282,6 @@ contract FranchiserFactoryHandler is Test {
         for (uint256 i = 0; i < lastFundedFranchisersArray.length; i++) {
             _increaseFundedFranchiserAccountBalance(lastFundedFranchisersArray[i], _amountsForFundMany[i]);
             ghost_totalFunded += _amountsForFundMany[i];
-
         }
 
         // add the created delegatees to the AddressSet
@@ -354,7 +339,10 @@ contract FranchiserFactoryHandler is Test {
         delete lastFundedFranchisersArray;
     }
 
-    function factory_expiredRecall(uint256 _fundedFranchiserIndex, address _expiredRecallCaller) external countCall("factory_expiredRecall") {
+    function factory_expiredRecall(uint256 _fundedFranchiserIndex, address _expiredRecallCaller)
+        external
+        countCall("factory_expiredRecall")
+    {
         console2.log("\n=== factory_expiredRecall attempt ===");
         if (fundedFranchisers.length() == 0) {
             console2.log("No franchisers to recall");
@@ -369,8 +357,6 @@ contract FranchiserFactoryHandler is Test {
         uint256 expiration = factory.expirations(_selectedFranchiser);
         console2.log("Expiration time: ", expiration);
 
-        _warpAroundExpiration(expiration);
-
         // before the recall, get the total amount delegated by the franchiser to be recalled  (including amounts it may have sub-delegated)
         uint256 _amountRecalled = getTotalAmountDelegatedByFranchiser(address(_selectedFranchiser));
 
@@ -384,49 +370,52 @@ contract FranchiserFactoryHandler is Test {
         console2.log("=== End of factory_expiredRecall ===\n");
     }
 
-        // This function will do a factory recall call for a subset of the last funded franchisers created by the factory (fundMany or permitAndFundMany)
-        function factory_expiredRecallMany(uint256 _numberFranchisersToRecall, address _expiredRecallCaller) external countCall("factory_expiredRecallMany") {
-            console2.log("\n=== factory_expiredRecallMany attempt ===");
-            if (lastFundedFranchisersArray.length < 3) {
-                delete lastFundedFranchisersArray;
-                return;
-            }
-            _numberFranchisersToRecall = bound(_numberFranchisersToRecall, 1, lastFundedFranchisersArray.length - 1);
-            vm.assume(_validActorAddress(_expiredRecallCaller));
-            address _delegator = lastFundedFranchisersArray[0].delegator();
-
-            uint256 expiration = factory.expirations(lastFundedFranchisersArray[0]);
-            console2.log("Expiration time: ", expiration);
-
-            _warpAroundExpiration(expiration);
-
-            address[] memory _delegateesForRecallMany = new address[](_numberFranchisersToRecall);
-            address[] memory _targetsForRecallMany = new address[](_numberFranchisersToRecall);
-
-            for (uint256 i = 0; i < _numberFranchisersToRecall; i++) {
-                // setup call to recallMany
-                Franchiser _fundedFranchiser = Franchiser(lastFundedFranchisersArray[i]);
-                _delegateesForRecallMany[i] = _fundedFranchiser.delegatee();
-                _targetsForRecallMany[i] = _delegator;
-
-                // decrease the funded franchiser balance mapping by the amount recalled (including amounts it may have sub-delegated)
-                // also bump the total recalled ghost var by the amount recalled
-                uint256 _amountRecalled = getTotalAmountDelegatedByFranchiser(address(_fundedFranchiser));
-                _decreaseFundedFranchiserAccountBalance(_fundedFranchiser, _amountRecalled);
-                ghost_totalRecalled += _amountRecalled;
-            }
-            vm.prank(_expiredRecallCaller);
-            factory.expiredRecallMany(_targetsForRecallMany, _delegateesForRecallMany);
-
-            // empty the lastFundedFranchisersArray, so factory_recallMany can only be called again after a new factory_fundMany
-            delete lastFundedFranchisersArray;
-            console2.log("=== End of factory_expiredRecallMany ===\n");
-        }
-
-    function factory_permitAndFund(uint256 _delegatorPrivateKey, address _delegatee, uint256 _amount, uint256 _expiration)
+    // This function will do a factory recall call for a subset of the last funded franchisers created by the factory (fundMany or permitAndFundMany)
+    function factory_expiredRecallMany(uint256 _numberFranchisersToRecall, address _expiredRecallCaller)
         external
-        countCall("factory_permitAndFund")
+        countCall("factory_expiredRecallMany")
     {
+        console2.log("\n=== factory_expiredRecallMany attempt ===");
+        if (lastFundedFranchisersArray.length < 3) {
+            delete lastFundedFranchisersArray;
+            return;
+        }
+        _numberFranchisersToRecall = bound(_numberFranchisersToRecall, 1, lastFundedFranchisersArray.length - 1);
+        vm.assume(_validActorAddress(_expiredRecallCaller));
+        address _delegator = lastFundedFranchisersArray[0].delegator();
+
+        uint256 expiration = factory.expirations(lastFundedFranchisersArray[0]);
+        console2.log("Expiration time: ", expiration);
+
+        address[] memory _delegateesForRecallMany = new address[](_numberFranchisersToRecall);
+        address[] memory _targetsForRecallMany = new address[](_numberFranchisersToRecall);
+
+        for (uint256 i = 0; i < _numberFranchisersToRecall; i++) {
+            // setup call to recallMany
+            Franchiser _fundedFranchiser = Franchiser(lastFundedFranchisersArray[i]);
+            _delegateesForRecallMany[i] = _fundedFranchiser.delegatee();
+            _targetsForRecallMany[i] = _delegator;
+
+            // decrease the funded franchiser balance mapping by the amount recalled (including amounts it may have sub-delegated)
+            // also bump the total recalled ghost var by the amount recalled
+            uint256 _amountRecalled = getTotalAmountDelegatedByFranchiser(address(_fundedFranchiser));
+            _decreaseFundedFranchiserAccountBalance(_fundedFranchiser, _amountRecalled);
+            ghost_totalRecalled += _amountRecalled;
+        }
+        vm.prank(_expiredRecallCaller);
+        factory.expiredRecallMany(_targetsForRecallMany, _delegateesForRecallMany);
+
+        // empty the lastFundedFranchisersArray, so factory_recallMany can only be called again after a new factory_fundMany
+        delete lastFundedFranchisersArray;
+        console2.log("=== End of factory_expiredRecallMany ===\n");
+    }
+
+    function factory_permitAndFund(
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _amount,
+        uint256 _expiration
+    ) external countCall("factory_permitAndFund") {
         _amount = _boundAmount(_amount);
         _delegatorPrivateKey = bound(_delegatorPrivateKey, 0xa11ce, 0xa11de);
         (address _delegator, uint256 _deadline, uint8 _v, bytes32 _r, bytes32 _s) =
@@ -447,10 +436,12 @@ contract FranchiserFactoryHandler is Test {
         delegatees.add(_delegatee);
     }
 
-    function factory_permitAndFundMany(uint256 _delegatorPrivateKey, address[] memory _rawDelegatees, uint256 _amount, uint256 _expiration)
-        external
-        countCall("factory_permitAndFundMany")
-    {
+    function factory_permitAndFundMany(
+        uint256 _delegatorPrivateKey,
+        address[] memory _rawDelegatees,
+        uint256 _amount,
+        uint256 _expiration
+    ) external countCall("factory_permitAndFundMany") {
         address[] memory _delegatees = _removeDuplicatesOrMatchingAddress(_rawDelegatees, address(0));
         uint256 _numberOfDelegatees = _delegatees.length;
         _amount = _bound(_amount, 1, 10_000e18);
@@ -469,7 +460,8 @@ contract FranchiserFactoryHandler is Test {
 
         // clear the storage of the lastFundedFranchisersArray and create a new one with call to fundMany
         delete lastFundedFranchisersArray;
-        lastFundedFranchisersArray = factory.permitAndFundMany(_delegatees, _amountsForFundMany, _expiration, _deadline, _v, _r, _s);
+        lastFundedFranchisersArray =
+            factory.permitAndFundMany(_delegatees, _amountsForFundMany, _expiration, _deadline, _v, _r, _s);
         vm.stopPrank();
 
         // add the delegator to the delegators AddressSet for tracking totals invariants
@@ -531,7 +523,9 @@ contract FranchiserFactoryHandler is Test {
         // (1 more than number delegatees, to make amount smaller to leave some in the franchiser)
         uint256 _subDelegateAmount = _amountInFranchiser / (_numberOfDelegatees + 1);
         if (_subDelegateAmount == 0) {
-            console2.log("Warning::: Sub-delegate amount after split for subDelegateMany is 0, skipping this sub-delegate attempt");
+            console2.log(
+                "Warning::: Sub-delegate amount after split for subDelegateMany is 0, skipping this sub-delegate attempt"
+            );
             return;
         }
         uint256[] memory _amountsForSubDelegateMany = new uint256[](_numberOfDelegatees);
@@ -546,7 +540,8 @@ contract FranchiserFactoryHandler is Test {
         // clear the storage of the lastSubDelegatedFranchisersArray and create a new one with call to subDelegateMany
         delete lastSubDelegatedFranchisersArray;
         vm.prank(_delegatee);
-        lastSubDelegatedFranchisersArray = _selectedFranchiser.subDelegateMany(_subDelegateesForSubDelegateMany, _amountsForSubDelegateMany);
+        lastSubDelegatedFranchisersArray =
+            _selectedFranchiser.subDelegateMany(_subDelegateesForSubDelegateMany, _amountsForSubDelegateMany);
         lastSubDelegatingFranchiser = _selectedFranchiser;
 
         // add the subDelegated franchisers to the subDelegatedFranchisers AddressSet so they can be found
@@ -567,7 +562,7 @@ contract FranchiserFactoryHandler is Test {
         // find a funded franchiser that has sub-delegatees
         uint256 _subDelegateCount = 0;
         uint256 _fundedFranchiserIndex = 0;
-        while ( (_fundedFranchiserIndex < fundedFranchisers.length()) && (_subDelegateCount == 0)) {
+        while ((_fundedFranchiserIndex < fundedFranchisers.length()) && (_subDelegateCount == 0)) {
             _subDelegateCount = Franchiser(fundedFranchisers.at(_fundedFranchiserIndex)).subDelegatees().length;
             if (_subDelegateCount == 0) _fundedFranchiserIndex++;
         }
@@ -585,13 +580,17 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // This function will do a franchiser unsubdelegate call for a subset of the last sub-delegated franchisers done by a franchiser
-    function franchiser_unSubDelegateMany(uint256 _numberFranchisersToUnSubDelegate) external countCall("franchiser_unSubDelegateMany") {
+    function franchiser_unSubDelegateMany(uint256 _numberFranchisersToUnSubDelegate)
+        external
+        countCall("franchiser_unSubDelegateMany")
+    {
         if (lastSubDelegatedFranchisersArray.length == 0) {
             console2.log("No sub-delegated franchisers to un-sub-delegate, skipping this call");
             delete lastSubDelegatedFranchisersArray;
             return;
         }
-        _numberFranchisersToUnSubDelegate = bound(_numberFranchisersToUnSubDelegate, 1, lastSubDelegatedFranchisersArray.length);
+        _numberFranchisersToUnSubDelegate =
+            bound(_numberFranchisersToUnSubDelegate, 1, lastSubDelegatedFranchisersArray.length);
 
         address[] memory _delegateesForUnSubDelegateMany = new address[](_numberFranchisersToUnSubDelegate);
         Franchiser[] memory _subDelegatedFranchisers = new Franchiser[](_numberFranchisersToUnSubDelegate);
@@ -608,10 +607,10 @@ contract FranchiserFactoryHandler is Test {
     }
 
     // This function will do recalls only from Franchisers that have sub-delegatees
-    function franchiser_recall(
-        uint256 _franchiserIndex,
-        bool _useSubDelegateFranchisers
-    ) external countCall("franchiser_recall") {
+    function franchiser_recall(uint256 _franchiserIndex, bool _useSubDelegateFranchisers)
+        external
+        countCall("franchiser_recall")
+    {
         if (fundedFranchisers.length() == 0) {
             return;
         }
@@ -623,7 +622,6 @@ contract FranchiserFactoryHandler is Test {
         // decrease the funded franchiser balance mapping and bump the total recalled ghost var by the amount recalled
         Franchiser _fundedFranchiser = _decreaseFundedFranchiserAccountBalance(_selectedFranchiser, _amountRecalled);
         ghost_totalRecalled += _amountRecalled;
-
 
         // recall the delegated funds
         address _delegator = _fundedFranchiser.delegator();
@@ -662,6 +660,7 @@ contract FranchiserFactoryHandler is Test {
     function callSummary() external {
         console2.log("\nCall summary:");
         console2.log("-------------------");
+        console2.log("factory_warpTime", calls["factory_warpTime"].calls);
         console2.log("factory_fund", calls["factory_fund"].calls);
         console2.log("factory_fundMany", calls["factory_fundMany"].calls);
         console2.log("factory_recall", calls["factory_recall"].calls);
@@ -674,7 +673,6 @@ contract FranchiserFactoryHandler is Test {
         console2.log("franchiser_subDelegateMany", calls["franchiser_subDelegateMany"].calls);
         console2.log("franchiser_unSubDelegate", calls["franchiser_unSubDelegate"].calls);
         console2.log("franchiser_unSubDelegateMany", calls["franchiser_unSubDelegateMany"].calls);
-        console2.log("franchiser_recall", calls["franchiser_recall"].calls);
         console2.log("-------------------\n");
         console2.log("Deepest sub-delegation tree depth: %d", calculateDeepestSubDelegationTree());
     }

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -160,7 +160,8 @@ contract FranchiserFactoryHandler is Test {
         bytes32 entropy = keccak256(abi.encodePacked(
             block.timestamp,
             block.number,
-            MAX_TIMESTAMP_OFFSET
+            MAX_TIMESTAMP_OFFSET,
+            msg.sender
         ));
 
         // Generate random magnitude and sign

--- a/test/handlers/FranchiserFactoryHandler.sol
+++ b/test/handlers/FranchiserFactoryHandler.sol
@@ -385,12 +385,19 @@ contract FranchiserFactoryHandler is Test {
 
         // This function will do a factory recall call for a subset of the last funded franchisers created by the factory (fundMany or permitAndFundMany)
         function factory_expiredRecallMany(uint256 _numberFranchisersToRecall) external countCall("factory_expiredRecallMany") {
+            console2.log("\n=== factory_expiredRecallMany attempt ===");
             if (lastFundedFranchisersArray.length < 3) {
                 delete lastFundedFranchisersArray;
                 return;
             }
             _numberFranchisersToRecall = bound(_numberFranchisersToRecall, 1, lastFundedFranchisersArray.length - 1);
             address _delegator = lastFundedFranchisersArray[0].delegator();
+
+            uint256 expiration = factory.expirations(lastFundedFranchisersArray[0]);
+            console2.log("Expiration time: ", expiration);
+
+            _warpAroundExpiration(expiration);
+
             address[] memory _delegateesForRecallMany = new address[](_numberFranchisersToRecall);
             address[] memory _targetsForRecallMany = new address[](_numberFranchisersToRecall);
 
@@ -411,6 +418,7 @@ contract FranchiserFactoryHandler is Test {
 
             // empty the lastFundedFranchisersArray, so factory_recallMany can only be called again after a new factory_fundMany
             delete lastFundedFranchisersArray;
+            console2.log("=== End of factory_expiredRecallMany ===\n");
         }
 
     function factory_permitAndFund(uint256 _delegatorPrivateKey, address _delegatee, uint256 _amount, uint256 _expiration)


### PR DESCRIPTION
Resolves #8, depends on #10

Add `factory_expiredRecall` and `factory_expiredRecallMany` to the existing handler contract, based on existing `factory_recall` and `factory_recallMany`.

## Testing Considerations
#### `factory_expiredRecall` requires timestamp manipulation to test expiration scenarios
   - use `_warpAroundExpiration` to randomize timestamp around expiration
   - The logs are deliberately kept for inspection during review

## Observations:
1. `factory_expiredRecallMany` often gets called more than `factory_expiredRecall`
    - Based on the comments it seems like it has to do with `factory_fundMany`
    - I find the behavior otherwise a bit strange, not sure if it should be investigated

2. Timestamp Behavior in Invariant Tests:
   - Default start: 1
   - Warped timestamp persists between function calls within same test
   - Resets to 1 between different invariant tests